### PR TITLE
Update schema and schema loading

### DIFF
--- a/saphon_json_automation.htm
+++ b/saphon_json_automation.htm
@@ -20,11 +20,26 @@
       color: green;
       font-weight: bold;
     }
+    /*
+    body div.container #show-description {
+      display: none !important;
+    }
+    */
+    /* Description elements */
+/*    :is(.form-group > small.form-text, div.card-body p ) { */
+    div[data-schematype] :is(small.form-text, p) {
+      display: none !important;
+    }
+/*    body div.container #show-description:checked ~ * :is(.form-group > small.form-text, div.card-body p) { */
+    body div.container #show-description:checked ~ * div[data-schematype] :is(small.form-text, p) {
+      display: block !important;
+    }
   </style>
 </head>
 
 <body>
   <div class="container">
+	<input type="checkbox" id="show-description" class="show-description btn btn-secondary btn-sm" />Show Descriptions
     <div class="columns">
       <h1 class="col-md-12">Auto-Saving JSON Editor Example</h1>
     </div>
@@ -32,8 +47,6 @@
       <div class="column col-md-12">
         <!-- Bootstrap buttons will automatically apply styles -->
         <button id="restore" class="btn btn-secondary btn-sm">Restore to Default</button>
-        <button id="hide-description" class="btn btn-secondary btn-sm">Hide Description</button>
-        <button id="show-description" class="btn btn-secondary btn-sm">Show Description</button>
         <button id="load-json" class="btn btn-secondary btn-sm">Load JSON</button>
         <button id="export-json" class="btn btn-secondary btn-sm">Export JSON</button>
         <button id="toggle-properties" class="btn btn-secondary btn-sm">Toggle Properties</button>
@@ -78,495 +91,13 @@
     };
 
     // Original schema for the editor (use your provided schema)
-    var originalSchema = {
+//    var originalSchema = {
+//    };
 
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$id": "https://github.com/levmichael/saphon/synthesis.schema.json",
-      "title": "Synthesis",
-      "description": "A SAPhon language synthesis document",
-      "type": "object",
-      "required": [
-        "doctype",
-        "name",
-        "glottolog_code",
-        "short_name",
-        "family",
-        "synthesis",
-        "alternate_names",
-        "iso_codes",
-        "countries",
-        "notes"
-      ],
-      "additionalProperties": false,
-      "properties": {
-        "doctype": {
-          "description": "The SAPhon language document type.",
-          "type": "string",
-          "const": "synthesis"
-        },
-        "name": {
-          "description": "The preferred citation form of the name of the language, in an orthographic form suited to academic publications.  It may contain spaces, hyphens, diacritics, and non-Latin glyphs that would occur in the preferred orthographic representation, e.g. **Arára do Mato Grosso**, **Aʔɨwa**, **Ashéninka (Apurucayali dialect)**.",
-          "type": "string"
-        },
-        "glottolog_code": {
-          "description": "The language code [as assigned in Glottolog](https://glottolog.org/)",
-          "type": "string",
-          "pattern": "^[a-z0-9]{4}[1-9][0-9]{3}$"
-        },
-        "short_name": {
-          "description": "The language name abbreviated to around 12 characters or less, to be used in tables and plots where space is tight.  Spaces, hyphens, diacritics, non-Latin glyphs are all permitted.",
-          "type": "string",
-          "pattern": "^.{1,12}$"
-        },
-        "family": {
-          "description": "This is the linguistic family of the language, or `Isolate` for linguistic isolates.",
-          "type": "string"
-        },
-        "natural_classes": {
-          "description": "TODO",
-          "type": "array",
-          "format": "table",
-          "items": {
-            "type": "object",
-            "required": [
-              "symbol",
-              "members"
-            ],
-            "additionalProperties": false,
-            "properties": {
-              "symbol": {
-                "description": "TODO",
-                "type": "string",
-                "pattern": "^([A-Z]|Ṽ)$"
-              },
-              "members": {
-                "description": "TODO",
-                "type": "array",
-                "items": {
-                  "$ref": "#/$defs/ipastring"
-                }
-              }
-            },
-            "format": "categories",
-          },
-          "minItems": 0
-        },
-        "synthesis": {
-          "description": "A prose description of the project's synthesis of the source materials. (TODO: rename field?)",
-          "type": "string"
-        },
-        "alternate_names": {
-          "description": "A list of alternative or outdated names for the language.",
-          "type": "array",
-          "items": {
-            "type": "string",
-            "minLength": 1
-          },
-          "minItems": 0
-        },
-        "iso_codes": {
-          "description": "A sequence of ISO 639-3 codes for the language, or of our own devising when the ISO codes are inadequate. When we need to distinguish language varieties not distinguished by ISO 639-3, we add a three letter extension to the code with an underscore '_' separator. Ordinarily the sequence contains only one code, but more values occur when multiple ISO codes refer to the same language (e.g. [Huaylas-Conchucos Quechua]('langs/HuaylasCQ.txt' contains codes `qxn`, `qwh`).",
-          "type": "array",
-          "items": {
-            "type": "string",
-            "pattern": "^(([a-z]{3})|([a-z]{3}_[a-z]{3}))$"
-          },
-          "minItems": 0
-        },
-        "countries": {
-          "description": "A list of country names where the language is indigenous.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "minItems": 0
-        },
-        "notes": {
-          "description": "A list of notes relating to the language.",
-          "type": "string"
-        },
-        "laryngeal_harmony": {
-          "description": "Boolean indicating presence of laryngeal harmony (true) or not (false).",
-          "type": "boolean"
-        },
-        "tone": {
-          "description": "Boolean indicating presence of tone (true) or not (false).",
-          "type": "boolean"
-        },
-        "coordinates": {
-          "description": "A list of the geographical coordinates for the language.",
-          "type": "array",
-          "items": {
-            "type": "object",
-            "required": [
-              "latitude",
-              "longitude"
-            ],
-            "additionalProperties": false,
-            "properties": {
-              "latitude": {
-                "description": "The coordinate latitude in decimal format, given to 3 decimal places.",
-                "type": "number",
-                "multipleOf": 0.001,
-                "minimum": -90.000,
-                "maximum": 90.000
-              },
-              "longitude": {
-                "description": "The coordinate longitude in decimal format, given to 3 decimal places.",
-                "type": "number",
-                "multipleOf": 0.001,
-                "minimum": -180.000,
-                "maximum": 180.000
-              },
-              "elevation_meters": {
-                "description": "The elevation in meters, rounded to the nearest integer meter. May be omitted if unknown.",
-                "type": "integer"
-              }
-            }
-          }
-        },
-        "morphemes": {
-          "description": "A list of morphemes in this language that are of note for one or more processes that are referred to in the document.",
-          "type": "array",
-          "items": {
-            "type": "object",
-            "required": [
-              "morpheme_id",
-              "morpheme_type",
-              "underlying_form",
-              "surface_forms",
-              "gloss"
-            ],
-            "additionalProperties": false,
-            "properties": {
-              "morpheme_id": {
-                "description": "A string identifier for the morpheme.",
-                "type": "string"
-              },
-              "morpheme_type": {
-                "description": "The kind of morphological element that undergoes the process, if the process's `type` is `morphological`. The value must be one of 'prefix', 'root', 'suffix', 'proclitic', 'enclitic', or if the process `type` is not `morphological`, this field must have the value `NA` to indicate an empty value. (TODO: review the list of allowable values)",
-                "type": "string",
-                "enum": [
-                  "prefix",
-                  "root",
-                  "suffix",
-                  "proclitic",
-                  "enclitic",
-                  "NA"
-                ]
-              },
-              "underlying_form": {
-                "description": "The underlying phonological form of the morpheme, using symbols from the International Phonetic Alphabet. (TODO: elaborate on the meaning of this field, e.g. UR vs. surface).",
-                "$ref": "#/$defs/ipastring"
-              },
-              "surface_forms": {
-                "description": "A list of surface allomorphs of this morpheme, using symbols from the International Phonetic Alphabet.",
-                "type": "array",
-                "items": {
-                  "$ref": "#/$defs/ipastring"
-                },
-                "minItems": 0
-              },
-              "gloss": {
-                "description": "English language gloss of the morpheme.",
-                "type": "string"
-              }
-            }
-          }
-        },
-        "phonemes": {
-          "description": "A list of the phonemes of the language, the allophones of each phoneme, and the environments in which they occur and the processes that are conditioned by each environment. This list is synthesized from the entries listed in the `ref` documents.",
-          "type": "array",
-          "format": "tabs-top",
-          "items": {
-            "format": "categories",
-            "type": "object",
-            "required": [
-              "phoneme",
-              "environments"
-            ],
-            "additionalProperties": false,
-            "properties": {
-              "phoneme": {
-                "description": "A phoneme of the language, using symbols from the International Phonetic Alphabet.",
-                "$ref": "#/$defs/ipastring"
-              },
-              "environments": {
-                "description": "A list of environments in which the phoneme may occur, and the allophones that are conditioned by that environment, and processes that yield each allophone. The values of this list are dicts.",
-                "type": "array",
-                "format": "tabs-top",
-                "items": {
-                  "type": "object",
-                  "format": "categories",
-                  "required": [
-                    "preceding",
-                    "following",
-                    "allophones"
-                  ],
-                  "additionalProperties": false,
-                  "properties": {
-                    "preceding": {
-                      "description": "A string representation of the part of the environment that precedes the phone.",
-                      "type": "string",
-                      "$comment": "TODO: test for pattern"
-                    },
-                    "following": {
-                      "description": "A string representation of the part of the environment that follows the phone.",
-                      "type": "string",
-                      "$comment": "TODO: test for pattern"
-                    },
-                    "allophones": {
-                      "description": "A list of dicts that represent allophones yielded by the phoneme in this environment. Multiple values in this list implies free variation among the allophones in this list.",
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "required": [
-                        ],
-                        "additionalProperties": false,
-                        "properties": {
-                          "processnames": {
-                            "description": "A list of process names that yield this allophone. Each value is a string. Thist list of process names does not imply free variation. Instead, the list may describe multiple processes that apply simultaneously, e.g. the process by which `phone` `e` yields `allophone` `ɛː` is described as the simultaneous application of two processes named `lowering` and `lengthening`.",
-                            "type": "array",
-                            "format": "table",
-                            "items": {
-                              "type": "string"
-                            }
-                          },
-                          "allophone": {
-                            "description": "The allophone yielded by the process(es) in this environment, as denoted in `processnames` and using symbols from the International Phonetic Alphabet.",
-                            "type": "string",
-                            "$comment": "TODO: test for pattern"
-                          }
-                        },
-                        "minItems": 0
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "processdetails": {
-          "description": "A list of details pertaining to all of the (nasal) processes active in the language. Each process described in this list must also refer to a process in the `phoneme` list one or more times. Each value in this list is a dict. The dict values of this list must not have repeated values of the conjunction of their `processtype` and `processname` values (see below).",
-          "type": "array",
-          "format": "tabs-top",
-          "items": {
-            "type": "object",
-            "required": [
-              "processname",
-              "processtype",
-              "alternation_type",
-              "domain",
-              "description",
-              "optionality",
-              "directionality"
-            ],
-            "additionalProperties": false,
-            "properties": {
-              "processname": {
-                "description": "The name of the process described. The value must match a string in the `processnames` list in the `phonemes` list. This value is a string.",
-                "type": "string",
-                "$comment": "TODO: test for phoneme value"
-              },
-              "processtype": {
-                "description": "The type of process described. The value is a string that must match one of the values of ... (TODO: add pointer to controlled vocabulary for this field). (TODO: check that this value matches the prefix of `processname`.",
-                "type": "string",
-                "$comment": "TODO: test for value"
-              },
-              "alternation_type": {
-                "description": "The type of alternation described. The value is a string that must match one of the values of `proc_alternation_vocab` (TODO: add pointer to controlled vocabulary for this field).",
-                "type": "string",
-                "$comment": "TODO: test for vocab value"
-              },
-              "domain": {
-                "description": "The domain in which the process occurs. The value is a string that must be `word-internal` or `cross-word`.",
-                "type": "string",
-                "enum": [
-                  "word-internal",
-                  "cross-word"
-                ]
-              },
-              "description": {
-                "description": "A prose description of the process.",
-                "type": "string",
-                "$comment": "TODO: test for vocab value; also, it is confusing to have a saphon name be the same as the json schema keyword 'description'"
-              },
-              "optionality": {
-                "description": "One of three values that describe whether the process applies without exception, optionally, or is not known. The valid values of these are, respectively, 'categorical', 'optional', and 'unknown'.",
-                "type": "string",
-                "enum": [
-                  "categorical",
-                  "optional",
-                  "unknown"
-                ]
-              },
-              "directionality": {
-                "description": "One of five values that describe whether in which direction the process applies. The valid values are 'leftward', 'rightward', 'bidirectional', 'circumdirectional', and 'unknown'. (TODO: full description of meanings of these values)",
-                "type": "string",
-                "enum": [
-                  "leftward",
-                  "rightward",
-                  "bidirectional",
-                  "circumdirectional",
-                  "unknown"
-                ]
-              },
-              "undergoers": {
-                "description": "A dict of the elements that are subject to this process, as listed under the keys `segments` and `morphemes.",
-                "type": "object",
-                "additionalProperties": false,
-                "properties": {
-                  "segments": {
-                    "description": "A dict of the segments that are subject to the process, as listed under the keys `units` and `positional_restrictions`. Note that the value is a simple dict and not a list of dicts as for `triggers`, `transparent`, and `opaque` values.",
-                    "$ref": "#/$defs/segments"
-                  },
-                  "morphemes": {
-                    "description": "A dict of morphemes that are subject to the process, as listed under the keys `units` and `positional_restrictions`. Note that the value is a simple dict and not a list of dicts as for `triggers`, `transparent`, and `opaque` values.",
-                    "$ref": "#/$defs/morphemes"
-                  }
-                }
-              },
-              "triggers": {
-                "description": "A dict of the elements that trigger this process, as listed under the keys `segments` and `morphemes:",
-                "type": "object",
-                "additionalProperties": false,
-                "properties": {
-                  "segments": {
-                    "description": "A list of dicts of the segments that trigger the process, as listed under the keys `units` and `positional_restriction`.",
-                    "$ref": "#/$defs/segmentslist"
-                  },
-                  "morphemes": {
-                    "description": "A list of dicts of morphemes that trigger the process, as listed under the keys `units` and `positional_restriction`.",
-                    "$ref": "#/$defs/morphemeslist"
-                  }
-                }
-              },
-              "transparent": {
-                "description": "A dict of the elements that are transparent to this process, as listed under the keys `segments` and `morphemes:",
-                "type": "object",
-                "additionalProperties": false,
-                "properties": {
-                  "segments": {
-                    "description": "A list of dicts of the segments that are transparent to the process, as listed under the keys `units` and `positional_restriction`.",
-                    "$ref": "#/$defs/segmentslist"
-                  },
-                  "morphemes": {
-                    "description": "A list of dicts of morphemes that are transparent to the process, as listed under the keys `units` and `positional_restriction`.",
-                    "$ref": "#/$defs/morphemeslist"
-                  }
-                }
-              },
-              "opaque": {
-                "description": "A dict of the elements that are opaque to this process. The elements are described by a dict:",
-                "type": "object",
-                "additionalProperties": false,
-                "properties": {
-                  "segments": {
-                    "description": "A list of dicts of the segments that are opaque to the process, as listed under the keys `units` and `positional_restriction`.",
-                    "$ref": "#/$defs/segmentslist"
-                  },
-                  "morphemes": {
-                    "description": "A list of dicts of morphemes that are opaque to the process, as listed under the keys `units` and `positional_restriction`.",
-                    "$ref": "#/$defs/morphemeslist"
-                  }
-                }
-              }
-            },
-            "format": "categories",
-          }
-        }
-      },
-      "format": "categories",
-      "basicCategoryTitle": "Main",
-      "$defs": {
-        "ipastring": {
-          "type": "string",
-          "pattern": ".*",
-          "$comment": "TODO: define pattern"
-        },
-        "morphunits": {
-          "description": "A list of valid `morpheme_ids` for this language.",
-          "type": "array",
-          "items": {
-            "description": "A valid `morpheme_id` for this language.",
-            "type": "string",
-            "pattern": ".+",
-            "$comment": "TODO: add validation"
-          },
-          "minItems": 0
-        },
-        "phonunits": {
-          "description": "A list of valid natural class and phoneme symbols for this language.",
-          "type": "array",
-          "format": "table",
-          "items": {
-            "description": "A valid natural class or phoneme symbol for this language.",
-            "type": "string",
-            "pattern": ".+",
-            "$comment": "TODO: add validation"
-          },
-          "minItems": 0
-        },
-        "positional_restrictions": {
-          "description": "A string that represents either a positional restriction (1-tuple or 2-tuple), a concatenation of positional restrictions using commas and greater signs, or one of the special vocabulary terms: Unspecified, Uncertain, None, NA.",
-          "oneOf": [
-            {
-              "type": "Explicit",
-              "pattern": "^\\{(root|prefix|suffix|proclitic|enclitic|clitic|word|morpheme|affix|syllable|foot|stressed\\ syllable|unstressed\\ syllable|pretonic\\ syllable|posttonic\\ syllable|utterance|VP)(,\\s*(initial|final|lmost|rmost|medial|onset|coda|nucleus))?\\}(\\s*(,|>)\\s*\\{(root|prefix|suffix|proclitic|enclitic|clitic|word|morpheme|affix|syllable|foot|stressed\\ syllable|unstressed\\ syllable|pretonic\\ syllable|posttonic\\ syllable|utterance|VP)(,\\s*(initial|final|lmost|rmost|medial|onset|coda|nucleus))?\\})*$",
-              "$comment": "This pattern allows for controlled vocabulary in positional restrictions. `foo` is restricted to linguistic elements, and `bar` is restricted to positional terms."
-            },
-            {
-              "type": "Special",
-              "enum": ["Unspecified", "Uncertain", "None", "NA"],
-              "$comment": "Special vocabulary terms: Unspecified, Uncertain, None, NA. These do not use brackets or concatenation."
-            }
-          ],
-          "$comment": "The value must either be a grammatical positional restriction or one of the special vocabulary terms."
-        },
-        "morphemes": {
-          "type": "object",
-          "required": [
-            "units",
-            "positional_restrictions"
-          ],
-          "additionalProperties": false,
-          "properties": {
-            "units": { "$ref": "#/$defs/morphunits" },
-            "positional_restrictions": { "$ref": "#/$defs/positional_restrictions" }
-          }
-        },
-        "segments": {
-          "type": "object",
-          "required": [
-            "units",
-            "positional_restrictions"
-          ],
-          "additionalProperties": false,
-          "properties": {
-            "units": { "$ref": "#/$defs/phonunits" },
-            "positional_restrictions": { "$ref": "#/$defs/positional_restrictions" }
-          }
-        },
-        "morphemeslist": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/morphemes"
-          }
-        },
-        "segmentslist": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/segments"
-          }
-        }
-      }
-    };
-    
     JSONEditor.defaults.options.theme = 'bootstrap5';
 
-    // Make a deep copy of the original schema to avoid mutations
-    var schema = JSON.parse(JSON.stringify(originalSchema));
+    // Define schema in scope shared by functions.
+    let schema = undefined;
 
     // Function to initialize the editor with custom property disabling logic
     // Variable to track the current state of properties (enabled or disabled)
@@ -617,39 +148,75 @@
     var savedData = localStorage.getItem('editorData');
     var initialData = savedData ? JSON.parse(savedData) : starting_value;
 
-    // Call initializeEditor to create the editor
-    initializeEditor(initialData);
+	/** Load schema locally or from github **/
+        //const schemaUrl = 'https://raw.githubusercontent.com/levmichael/saphon/spreadsheet/saphonlang.schema.json';
+        const schemaUrl = '/saphonlang.schema.json';
 
-    // Hook up the Restore to Default button with confirmation modal
-    document.getElementById('restore').addEventListener('click', function () {
-      // Show the confirmation modal
-      document.getElementById('confirmation-modal').classList.add('active');
-    });
+        // Fetch the schema from GitHub
+        fetch(schemaUrl)
+            .then(response => response.json())
+            .then(originalSchema => {
+                // Make a deep copy of the original schema to avoid mutations and save to var in outer scope.
+                schema = JSON.parse(JSON.stringify(originalSchema));
 
-    // Event listener for "Yes" button in confirmation modal
-    document.getElementById('confirm-yes').addEventListener('click', function () {
-      // Proceed with restoring to default
-      editor.setValue(starting_value);
-      hasChanges = true; // Indicate that changes were made
-      // Hide the modal
-      document.getElementById('confirmation-modal').classList.remove('active');
-      // Clear saved data
-      localStorage.removeItem('editorData');
-    });
+                // Call initializeEditor to create the editor
+                initializeEditor(initialData);
 
-    // Event listener for "No" button in confirmation modal
-    document.getElementById('confirm-no').addEventListener('click', function () {
-      // Hide the modal without doing anything
-      document.getElementById('confirmation-modal').classList.remove('active');
-    });
+/*
+                // Initialize the JSON Editor with the fetched schema
+                const editor = new JSONEditor(document.getElementById('editor_holder'), {
+                    schema: schema
+                });
 
-    // Close the modal when clicking outside or on the close button
-    var modalOverlays = document.querySelectorAll('#confirmation-modal .modal-overlay, #confirmation-modal .btn-clear');
-    modalOverlays.forEach(function (element) {
-      element.addEventListener('click', function () {
-        document.getElementById('confirmation-modal').classList.remove('active');
-      });
-    });
+                // Handle the submit button
+                document.getElementById('submit').addEventListener('click', () => {
+                    const json = editor.getValue();
+                    document.getElementById('output').textContent = JSON.stringify(json, null, 2);
+                });
+
+                // Handle the reset button
+                document.getElementById('reset').addEventListener('click', () => {
+                    editor.setValue({});
+                    document.getElementById('output').textContent = '';
+                });
+*/
+
+                // Hook up the Restore to Default button with confirmation modal
+                document.getElementById('restore').addEventListener('click', function () {
+                  // Show the confirmation modal
+                  document.getElementById('confirmation-modal').classList.add('active');
+                });
+
+                // Event listener for "Yes" button in confirmation modal
+                document.getElementById('confirm-yes').addEventListener('click', function () {
+                  // Proceed with restoring to default
+                  editor.setValue(starting_value);
+                  hasChanges = true; // Indicate that changes were made
+                  // Hide the modal
+                  document.getElementById('confirmation-modal').classList.remove('active');
+                  // Clear saved data
+                  localStorage.removeItem('editorData');
+                });
+
+                // Event listener for "No" button in confirmation modal
+                document.getElementById('confirm-no').addEventListener('click', function () {
+                  // Hide the modal without doing anything
+                  document.getElementById('confirmation-modal').classList.remove('active');
+                });
+
+                // Close the modal when clicking outside or on the close button
+                var modalOverlays = document.querySelectorAll('#confirmation-modal .modal-overlay, #confirmation-modal .btn-clear');
+                modalOverlays.forEach(function (element) {
+                  element.addEventListener('click', function () {
+                    document.getElementById('confirmation-modal').classList.remove('active');
+                  });
+                });
+            })
+            .catch(error => {
+                console.error('Error loading schema:', error);
+                document.getElementById('output').textContent = 'Error loading schema. Please check the console for more details.';
+            });
+
 
     // Function to save the editor data to localStorage
     function saveEditorData() {
@@ -677,6 +244,7 @@
     // Set interval to check for changes every 3 seconds
     saveInterval = setInterval(autoSave, 3000);
 
+/*
     // Function to hide descriptions and update schema accordingly
     function hideDes(obj) {
       for (var key in obj) {
@@ -697,8 +265,8 @@
       }
     }
 
-    // Function to show descriptions and update schema accordingly. 
-    // Note from Jiacheng: I tried to use a single button to toggle the two functions by implementing a flag, in the form of description_state. Then, depending on the state of that, we should be able to have just one function Toggle_Description that does both. However, eventually I realized that my javascript skill could not make it happen.  
+    // Function to show descriptions and update schema accordingly.
+    // Note from Jiacheng: I tried to use a single button to toggle the two functions by implementing a flag, in the form of description_state. Then, depending on the state of that, we should be able to have just one function Toggle_Description that does both. However, eventually I realized that my javascript skill could not make it happen.
     function showDes(obj) {
       for (var key in obj) {
         if (obj.hasOwnProperty(key)) {
@@ -721,6 +289,7 @@
         }
       }
     }
+*/
 
     // Helper function to retrieve a schema fragment by its $id
     function getSchemaFragmentById(schema, id) {
@@ -737,6 +306,7 @@
       return null;
     }
 
+/*
     // Hide Description button
     document.getElementById('hide-description').addEventListener('click', function () {
       var currentData = editor.getValue();
@@ -756,7 +326,7 @@
       showDes(schema);
       initializeEditor(currentData);
     });
-
+*/
     // Load JSON from file
     document.getElementById('load-json').addEventListener('click', function () {
       document.getElementById('file-input').click();

--- a/saphonlang.schema.json
+++ b/saphonlang.schema.json
@@ -206,10 +206,6 @@
       "minItems": 0
     },
     "positional_restrictions": {
-      "$comment": "(TODO: do not parse the strings that appear in the data entry spreadsheet into constituent parts right now; later we can inventory all of the string values and decide whether to split this into multiple fields.); TODO: validation",
-      "type": "string"
-    },
-    "positional_restrictions": {
       "description": "A string that represents either a positional restriction (1-tuple or 2-tuple), a concatenation of positional restrictions using commas and greater signs, or one of the special vocabulary terms: Unspecified, Uncertain, None, NA.",
       "oneOf": [
         {

--- a/saphonlang.schema.json
+++ b/saphonlang.schema.json
@@ -1,0 +1,577 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/levmichael/saphon/saphonlang.schema.json",
+  "title": "saphonlang",
+  "format": "categories",
+  "description": "A SAPhon language synthesis",
+  "type": "object",
+  "required": [
+    "info",
+    "synthesis",
+    "sources"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "info": {
+      "format": "categories",
+      "basicCategoryTitle": "basic",
+      "description": "General language metadata",
+      "type": "object",
+      "required": [
+        "name",
+        "short_name",
+        "alternate_names",
+        "glottolog_code",
+        "iso_codes",
+        "family",
+        "countries",
+	"coordinates",
+        "notes"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "description": "The preferred citation form of the name of the language, in an orthographic form suited to academic publications.  It may contain spaces, hyphens, diacritics, and non-Latin glyphs that would occur in the preferred orthographic representation, e.g. **Arára do Mato Grosso**, **Aʔɨwa**, **Ashéninka (Apurucayali dialect)**.",
+          "type": "string"
+        },
+        "short_name": {
+          "description": "The language name abbreviated to around 12 characters or less, to be used in tables and plots where space is tight.  Spaces, hyphens, diacritics, non-Latin glyphs are all permitted.",
+          "type": "string",
+          "pattern": "^.{1,12}$"
+        },
+        "alternate_names": {
+          "description": "A list of alternative or outdated names for the language.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "minItems": 0
+        },
+        "glottolog_code": {
+          "description": "The language code [as assigned in Glottolog](https://glottolog.org/)",
+          "type": "string",
+          "pattern": "^[a-z0-9]{4}[1-9][0-9]{3}$"
+        },
+        "iso_codes": {
+          "description": "A sequence of ISO 639-3 codes for the language, or of our own devising when the ISO codes are inadequate. When we need to distinguish language varieties not distinguished by ISO 639-3, we add a three letter extension to the code with an underscore '_' separator. Ordinarily the sequence contains only one code, but more values occur when multiple ISO codes refer to the same language (e.g. [Huaylas-Conchucos Quechua]('langs/HuaylasCQ.txt' contains codes `qxn`, `qwh`).",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^(([a-z]{3})|([a-z]{3}_[a-z]{3}))$"
+          },
+          "minItems": 0
+        },
+        "family": {
+          "description": "This is the linguistic family of the language, or `Isolate` for linguistic isolates.",
+          "type": "string"
+        },
+        "countries": {
+          "description": "A list of country names where the language is indigenous.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 0
+        },
+        "coordinates": {
+          "description": "A list of the geographical coordinates for the language.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "latitude",
+              "longitude"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "latitude": {
+                "description": "The coordinate latitude in decimal format, given to 3 decimal places.",
+                "type": "number",
+                "multipleOf": 0.001,
+            "minimum": -90.000,
+            "maximum": 90.000
+              },
+              "longitude": {
+                "description": "The coordinate longitude in decimal format, given to 3 decimal places.",
+                "type": "number",
+                "multipleOf": 0.001,
+            "minimum": -180.000,
+            "maximum": 180.000
+              },
+              "elevation_meters": {
+                "description": "The elevation in meters, rounded to the nearest integer meter. May be omitted if unknown.",
+                "type": "integer"
+              }
+            }
+          }
+        },
+        "notes": {
+          "description": "Notes relating to the language",
+          "$ref": "#/$defs/notes"
+        }
+      }
+    },
+    "synthesis": {
+      "format": "categories",
+      "basicCategoryTitle": "basic",
+      "type": "object",
+      "required": [
+        "summary",
+        "notes",
+        "natural_classes",
+        "phonemes",
+        "morphemes",
+        "processdetails"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "summary": {
+          "description": "A prose description of the project's synthesis of the source materials. (TODO: rename field?)",
+          "type": "string"
+        },
+        "notes": {
+          "description": "Notes relating to the synthesis",
+          "$ref": "#/$defs/notes"
+        },
+        "natural_classes": {
+          "$ref": "#/$defs/natural_classes"
+        },
+        "morphemes": { "$ref": "#/$defs/morphemes" },
+        "phonemes": { "$ref": "#/$defs/phonemes" },
+        "processdetails": { "$ref": "#/$defs/processdetails" },
+        "laryngeal_harmony": { "$ref": "#/$defs/laryngeal_harmony" },
+        "tone": { "$ref": "#/$defs/tone" }
+      }
+    },
+    "sources": {
+      "type": "array",
+      "items": {
+         "$ref": "#/$defs/source"
+      }
+    }
+  },
+  "$defs": {
+    "laryngeal_harmony": {
+      "description": "Boolean indicating presence of laryngeal harmony (true) or not (false).",
+      "type": "boolean"
+    },
+    "tone": {
+      "description": "Boolean indicating presence of tone (true) or not (false).",
+      "type": "boolean"
+    },
+    "notes": {
+      "type": "string",
+      "minLength": 0
+    },
+    "ipachar": {
+      "type": "string",
+      "pattern": "^(p|pː|pʲ|pʷ|ps|ʰb|b|bː|bʲ|bʷ|bz|bβ|bʰ|t̪|t̪ʙ|d̪|t|tˣ|ʰt|tː|tʲ|tʷ|t̺|ʰd|d|dː|dʲ|ʈ|ɖ|c|ʰc|ʰɟ|ɟ|k|kʲ|kˣ|ʰk|kː|ʰkʷ|kʷ|kʷː|k̪|kʷʲ|kp|tk|ɡ|ɡː|ɡʷ|q|qʷ|ɢ|ʔ|ʔʲ|ts|tsʲ|dz|nð|tʃ|tʃʲ|dʒ|dʃ|ʈʂ|ɖʐ|tɕ|cç|cçʰ|ɟʝ|ɓ̥|ɓ|ɗ̥|ɗ|ʄ|ɠ|pʰ|pʲʰ|t̪ʰ|d̪ʰ|tʰ|tʲʰ|dʰ|ʈʰ|cʰ|kʰ|kʲʰ|qʰ|tsʰ|tsʲʰ|tʃʰ|ʈʂʰ|pʼ|b̰|ʔb|t̪ʼ|tʼ|tʲʼ|t̰|t◌̰|d̰|ʔd|ʈʼ|cʼ|c̰|ɟ̰|kʼ|kʲʼ|kʷʼ|k̰|kʷ̰|kʷ◌̰|ɡ̰|qʼ|tsʼ|ʔdʒ|tʃʼ|ʈʂʼ|mp|mpʲ|mɸʲ|mb|mbʲ|nt|ntʲ|ns|nsʲ|nd|ndʲ|ŋk|ŋɡ|ŋɡʷ|ntʃ|ndʒ|ɳʈʂ|ɳɖʐ|nts|ndz|ndzʲ|ʰm|mʰ|m̥|m|mʼ|m̰|mʲ|mʷ|mː|ɱ|n̪|ʰn|nʰ|n̥|n|nʲ|nː|n̰|ɲʰ|ʰɲ|ɲ|ɲ̰|ɲː|ɲ̥|ŋ|ŋʷ|ŋ̥|ɴ|N|ɸ|ɸʲ|β|βʲ|fʷ|f|v|θ|s̪|θʲ|ð|s|sʲ|sʼ|sʰ|s̺|z|ɼ|ʂ|ʐ|ʃ|ʒ|ʒ̺|ɕ|ç|ʝ|x|xʲ|xl|xʷ|ɣ|ɣʷ|χ|χʷ|ʁ|h|h̃|hʲ|hʷ|ɦ|ʍ|β̞|ʋ|ð̞|ɹ|ɻ|ɻ̥|ʰj|j|j̃|j̥|jʼ|j̰|jː|ɰ|ʰw|wʰ|w̥|w|w̃|wʼ|w̰|wʲ|wː|ʔw|ʕ|l̪|l̥|ɬ|ɺ̥|l|lʲ|lʼ|lː|ɺ|ɮ|ɭ|ɭʲ|ʎ|kl|ʰɾ|ɾ|ɾ̃|ɾʲ|ʔɾ|ɽʰ|ɽ|ⱱ|r̥|r|ʀ|ʙ|i|ĩ|ḭ|ḭ̃|iː|ĩː|iʰ|iˀ|ĭ|ĭ̃|y|ỹ|ɨ|ɨ̃|ɨ̰|ɨː|ɨ̃ː|ɨ̘|ɨi|ɨ̆|ɨ̆̃|ʉ|ʉ̃|ʉː|ʉ̃ː|ɯ|ɯ̃|ɯ̰|ɯː|ɯ̃ː|ɯi|u|ũ|ṵ|ṵ̃|uː|ũː|uʰ|uˀ|ŭ|ŭ̃|ɪ|ɪ̃|ɪː|ɪ̆|ʏ|ʊ|ʊ̃|ʊː|e|ẽ|ḛ|ḛ̃|eː|ẽː|eʰ|eu|eˀ|ø|øː|ø̃|ɘ|ɵ|ɵː|ɤ|ɤ̃|ɤː|o|õ̰|o̰|õ|oː|õː|oʰ|oʲ|õʲ|o̝|oˀ|ə|ə̃|ə̰|ə̰̃|əː|ə̃ː|ɛ|ɛ̃|ɛː|ɛ̃ː|ɛ̰|œ|œ̃|ɜ|ʌ|ʌ̃|ʌː|ʌ̃ː|ɔ|ɔ̃|ɔː|ɔ̃ː|æ|æ̃|æː|æ̃ː|ɐ|ɐ̃|a|ã|a̰|ã̰|aː|ãː|aʲ|ãʲ|aʲː|aʰ|aˀ|ɑ|ɑ̃|ɑ̰|ɑː|ɒ|ɒ̃|ɒː|ɒ̃ː)$"
+    },
+    "ipastring": {
+      "type": "string",
+      "pattern": "^(p|pː|pʲ|pʷ|ps|ʰb|b|bː|bʲ|bʷ|bz|bβ|bʰ|t̪|t̪ʙ|d̪|t|tˣ|ʰt|tː|tʲ|tʷ|t̺|ʰd|d|dː|dʲ|ʈ|ɖ|c|ʰc|ʰɟ|ɟ|k|kʲ|kˣ|ʰk|kː|ʰkʷ|kʷ|kʷː|k̪|kʷʲ|kp|tk|ɡ|ɡː|ɡʷ|q|qʷ|ɢ|ʔ|ʔʲ|ts|tsʲ|dz|nð|tʃ|tʃʲ|dʒ|dʃ|ʈʂ|ɖʐ|tɕ|cç|cçʰ|ɟʝ|ɓ̥|ɓ|ɗ̥|ɗ|ʄ|ɠ|pʰ|pʲʰ|t̪ʰ|d̪ʰ|tʰ|tʲʰ|dʰ|ʈʰ|cʰ|kʰ|kʲʰ|qʰ|tsʰ|tsʲʰ|tʃʰ|ʈʂʰ|pʼ|b̰|ʔb|t̪ʼ|tʼ|tʲʼ|t̰|t◌̰|d̰|ʔd|ʈʼ|cʼ|c̰|ɟ̰|kʼ|kʲʼ|kʷʼ|k̰|kʷ̰|kʷ◌̰|ɡ̰|qʼ|tsʼ|ʔdʒ|tʃʼ|ʈʂʼ|mp|mpʲ|mɸʲ|mb|mbʲ|nt|ntʲ|ns|nsʲ|nd|ndʲ|ŋk|ŋɡ|ŋɡʷ|ntʃ|ndʒ|ɳʈʂ|ɳɖʐ|nts|ndz|ndzʲ|ʰm|mʰ|m̥|m|mʼ|m̰|mʲ|mʷ|mː|ɱ|n̪|ʰn|nʰ|n̥|n|nʲ|nː|n̰|ɲʰ|ʰɲ|ɲ|ɲ̰|ɲː|ɲ̥|ŋ|ŋʷ|ŋ̥|ɴ|N|ɸ|ɸʲ|β|βʲ|fʷ|f|v|θ|s̪|θʲ|ð|s|sʲ|sʼ|sʰ|s̺|z|ɼ|ʂ|ʐ|ʃ|ʒ|ʒ̺|ɕ|ç|ʝ|x|xʲ|xl|xʷ|ɣ|ɣʷ|χ|χʷ|ʁ|h|h̃|hʲ|hʷ|ɦ|ʍ|β̞|ʋ|ð̞|ɹ|ɻ|ɻ̥|ʰj|j|j̃|j̥|jʼ|j̰|jː|ɰ|ʰw|wʰ|w̥|w|w̃|wʼ|w̰|wʲ|wː|ʔw|ʕ|l̪|l̥|ɬ|ɺ̥|l|lʲ|lʼ|lː|ɺ|ɮ|ɭ|ɭʲ|ʎ|kl|ʰɾ|ɾ|ɾ̃|ɾʲ|ʔɾ|ɽʰ|ɽ|ⱱ|r̥|r|ʀ|ʙ|i|ĩ|ḭ|ḭ̃|iː|ĩː|iʰ|iˀ|ĭ|ĭ̃|y|ỹ|ɨ|ɨ̃|ɨ̰|ɨː|ɨ̃ː|ɨ̘|ɨi|ɨ̆|ɨ̆̃|ʉ|ʉ̃|ʉː|ʉ̃ː|ɯ|ɯ̃|ɯ̰|ɯː|ɯ̃ː|ɯi|u|ũ|ṵ|ṵ̃|uː|ũː|uʰ|uˀ|ŭ|ŭ̃|ɪ|ɪ̃|ɪː|ɪ̆|ʏ|ʊ|ʊ̃|ʊː|e|ẽ|ḛ|ḛ̃|eː|ẽː|eʰ|eu|eˀ|ø|øː|ø̃|ɘ|ɵ|ɵː|ɤ|ɤ̃|ɤː|o|õ̰|o̰|õ|oː|õː|oʰ|oʲ|õʲ|o̝|oˀ|ə|ə̃|ə̰|ə̰̃|əː|ə̃ː|ɛ|ɛ̃|ɛː|ɛ̃ː|ɛ̰|œ|œ̃|ɜ|ʌ|ʌ̃|ʌː|ʌ̃ː|ɔ|ɔ̃|ɔː|ɔ̃ː|æ|æ̃|æː|æ̃ː|ɐ|ɐ̃|a|ã|a̰|ã̰|aː|ãː|aʲ|ãʲ|aʲː|aʰ|aˀ|ɑ|ɑ̃|ɑ̰|ɑː|ɒ|ɒ̃|ɒː|ɒ̃ː)+$"
+    },
+    "stringarray": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "ipachararray": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/ipachar"
+      }
+    },
+    "morphunits": {
+      "description": "A list of valid `morpheme_ids` for this language.",
+      "type": "array",
+      "items": {
+        "description": "A valid `morpheme_id` for this language.",
+        "type": "string",
+        "pattern": ".+"
+      },
+      "minItems": 0
+    },
+    "phonunits": {
+      "description": "A list of valid natural class and phoneme symbols for this language.",
+      "type": "array",
+      "items": {
+        "description": "A valid natural class or phoneme symbol for this language.",
+        "type": "string",
+    "pattern": ".+",
+    "$comment": "TODO: add validation"
+      },
+      "minItems": 0
+    },
+    "positional_restrictions": {
+      "$comment": "(TODO: do not parse the strings that appear in the data entry spreadsheet into constituent parts right now; later we can inventory all of the string values and decide whether to split this into multiple fields.); TODO: validation",
+      "type": "string"
+    },
+    "positional_restrictions": {
+      "description": "A string that represents either a positional restriction (1-tuple or 2-tuple), a concatenation of positional restrictions using commas and greater signs, or one of the special vocabulary terms: Unspecified, Uncertain, None, NA.",
+      "oneOf": [
+        {
+          "type": "Explicit",
+          "pattern": "^\\{(root|prefix|suffix|proclitic|enclitic|clitic|word|morpheme|affix|syllable|foot|stressed\\ syllable|unstressed\\ syllable|pretonic\\ syllable|posttonic\\ syllable|utterance|VP)(,\\s*(initial|final|lmost|rmost|medial|onset|coda|nucleus))?\\}(\\s*(,|>)\\s*\\{(root|prefix|suffix|proclitic|enclitic|clitic|word|morpheme|affix|syllable|foot|stressed\\ syllable|unstressed\\ syllable|pretonic\\ syllable|posttonic\\ syllable|utterance|VP)(,\\s*(initial|final|lmost|rmost|medial|onset|coda|nucleus))?\\})*$",
+          "$comment": "This pattern allows for controlled vocabulary in positional restrictions. `foo` is restricted to linguistic elements, and `bar` is restricted to positional terms."
+        },
+        {
+          "type": "Special",
+          "enum": ["Unspecified", "Uncertain", "None", "NA"],
+          "$comment": "Special vocabulary terms: Unspecified, Uncertain, None, NA. These do not use brackets or concatenation."
+        }
+      ],
+      "$comment": "The value must either be a grammatical positional restriction or one of the special vocabulary terms."
+    },
+    "morphemes": {
+      "type": "object",
+      "required": [
+        "units",
+        "positional_restrictions"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "units": { "$ref": "#/$defs/morphunits" },
+        "positional_restrictions": { "$ref": "#/$defs/positional_restrictions" }
+      }
+    },
+    "natural_classes": {
+      "description": "TODO",
+      "format": "categories",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "symbol",
+          "members"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "symbol": {
+            "description": "TODO",
+            "type": "string",
+            "pattern": "^([A-Z]|Ṽ)$" 
+          },
+          "members": {
+            "$ref": "#/$defs/ipachararray",
+            "minItems": 2
+          }
+        }
+      },
+      "minItems": 0
+    },
+    "segments": {
+      "type": "object",
+      "required": [
+        "units",
+        "positional_restrictions"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "units": { "$ref": "#/$defs/phonunits" },
+        "positional_restrictions": { "$ref": "#/$defs/positional_restrictions" }
+      }
+    },
+    "morphemeslist": {
+      "type": "array",
+      "items": {
+         "$ref": "#/$defs/morphemes"
+      }
+    },
+    "segmentslist": {
+      "type": "array",
+      "items": {
+         "$ref": "#/$defs/segments"
+      }
+    },
+    "morphemes": {
+      "description": "A list of morphemes in this language that are of note for one or more processes that are referred to in the document.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "morpheme_id",
+          "morpheme_type",
+      "underlying_form",
+      "surface_forms",
+      "gloss"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "morpheme_id": {
+            "description": "A string identifier for the morpheme.",
+            "type": "string"
+          },
+          "morpheme_type": {
+            "description": "The kind of morphological element that undergoes the process, if the process's `type` is `morphological`. The value must be one of 'prefix', 'root', 'suffix', 'proclitic', 'enclitic', or if the process `type` is not `morphological`, this field must have the value `NA` to indicate an empty value. (TODO: review the list of allowable values)",
+            "type": "string",
+        "enum": [
+              "prefix",
+              "root",
+              "suffix",
+              "proclitic",
+              "enclitic",
+              "NA"
+            ]
+          },
+          "underlying_form": {
+            "description": "The underlying phonological form of the morpheme, using symbols from the International Phonetic Alphabet.",
+            "$ref": "#/$defs/ipastring"
+          },
+          "surface_forms": {
+            "description": "A list of surface allomorphs of this morpheme, using symbols from the International Phonetic Alphabet.",
+            "type": "array",
+            "items": {
+              "$ref": "#/$defs/ipastring"
+            },
+            "minItems": 0
+          },
+          "gloss": {
+            "description": "English language gloss of the morpheme.",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "phonemes": {
+      "description": "A list of the phonemes of the language, the allophones of each phoneme, and the environments in which they occur and the processes that are conditioned by each environment. This list is synthesized from the entries listed in the `ref` documents.",
+      "type": "array",
+      "items": {
+        "format": "categories",
+        "type": "object",
+        "required": [
+          "phoneme",
+          "environments"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "phoneme": {
+            "description": "A phoneme of the language, using symbols from the International Phonetic Alphabet.",
+            "$ref": "#/$defs/ipachar"
+          },
+          "environments": {
+            "description": "A list of environments in which the phoneme may occur, and the allophones that are conditioned by that environment, and processes that yield each allophone. The values of this list are dicts.",
+            "type": "array",
+            "items": {
+              "format": "categories",
+              "type": "object",
+              "required": [
+                "preceding",
+                "following",
+                "allophones"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "preceding": {
+                  "description": "A string representation of the part of the environment that precedes the phone.",
+                  "type": "string",
+                  "minLength": 0
+                },
+                "following": {
+                  "description": "A string representation of the part of the environment that follows the phone.",
+                  "type": "string",
+                  "minLength": 0
+                },
+                "allophones": {
+                  "description": "A list of dicts that represent allophones yielded by the phoneme in this environment. Multiple values in this list implies free variation among the allophones in this list.",
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": [
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "processnames": {
+                        "description": "A list of process names that yield this allophone. Each value is a string. Thist list of process names does not imply free variation. Instead, the list may describe multiple processes that apply simultaneously, e.g. the process by which `phone` `e` yields `allophone` `ɛː` is described as the simultaneous application of two processes named `lowering` and `lengthening`.",
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "allophone": {
+                        "description": "The allophone yielded by the process(es) in this environment, as denoted in `processnames` and using symbols from the International Phonetic Alphabet.",
+                        "type": "string"
+                      }
+                    },
+                    "minItems": 0
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "processdetails": {
+      "description": "A list of details pertaining to all of the (nasal) processes active in the language. Each process described in this list must also refer to a process in the `phoneme` list one or more times. Each value in this list is a dict. The dict values of this list must not have repeated values of the conjunction of their `processtype` and `processname` values (see below).",
+      "type": "array",
+      "items": {
+      "format": "categories",
+      "basicCategoryTitle": "Main",
+        "type": "object",
+        "required": [
+          "processname",
+          "processtype",
+          "alternation_type",
+          "domain",
+          "summary",
+          "optionality",
+          "directionality"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "format": "categories",
+          "processname": {
+            "description": "The name of the process described. The value must match a string in the `processnames` list in the `phonemes` list. This value is a string.",
+            "type": "string"
+          },
+          "processtype": {
+            "description": "The type of process described. The value is a string that must match one of the values of ... (TODO: add pointer to controlled vocabulary for this field). (TODO: check that this value matches the prefix of `processname`.",
+            "type": "string"
+          },
+          "alternation_type": {
+            "description": "The type of alternation described. The value is a string that must match one of the values of `proc_alternation_vocab` (TODO: add pointer to controlled vocabulary for this field).",
+            "type": "string"
+          },
+          "domain": {
+            "description": "The domain in which the process occurs. The value is a string that must be `word-internal` or `cross-word`.",
+            "type": "string",
+        "enum": [
+          "word-internal",
+          "cross-word"
+        ]
+          },
+          "summary": {
+            "description": "A prose description of the process.",
+            "type": "string",
+        "$comment": "TODO: test for vocab value; also, it is confusing to have a saphon name be the same as the json schema keyword 'description'"
+          },
+          "optionality": {
+            "description": "One of three values that describe whether the process applies without exception, optionally, or is not known. The valid values of these are, respectively, 'categorical', 'optional', and 'unknown'.",
+            "type": "string",
+        "enum": [
+          "categorical",
+          "optional",
+          "unknown"
+        ]
+          },
+          "directionality": {
+            "description": "One of five values that describe whether in which direction the process applies. The valid values are 'leftward', 'rightward', 'bidirectional', 'circumdirectional', and 'unknown'. (TODO: full description of meanings of these values)",
+            "type": "string",
+        "enum": [
+          "leftward",
+          "rightward",
+          "bidirectional",
+          "circumdirectional",
+          "unknown"
+        ]
+          },
+          "undergoers": {
+            "format": "categories",
+            "basicCategoryTitle": "basic",
+            "description": "A dict of the elements that are subject to this process, as listed under the keys `segments` and `morphemes.",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "segments": {
+                "description": "A dict of the segments that are subject to the process, as listed under the keys `units` and `positional_restrictions`. Note that the value is a simple dict and not a list of dicts as for `triggers`, `transparent`, and `opaque` values.",
+                "$ref": "#/$defs/segments"
+              },
+              "morphemes": {
+                "description": "A dict of morphemes that are subject to the process, as listed under the keys `units` and `positional_restrictions`. Note that the value is a simple dict and not a list of dicts as for `triggers`, `transparent`, and `opaque` values.",
+                "$ref": "#/$defs/morphemes"
+              }
+        }
+          },
+          "triggers": {
+            "format": "categories",
+            "basicCategoryTitle": "basic",
+            "description": "A dict of the elements that trigger this process, as listed under the keys `segments` and `morphemes:",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "segments": {
+                "description": "A list of dicts of the segments that trigger the process, as listed under the keys `units` and `positional_restriction`.",
+                "$ref": "#/$defs/segmentslist"
+              },
+              "morphemes": {
+                "description": "A list of dicts of morphemes that trigger the process, as listed under the keys `units` and `positional_restriction`.",
+                "$ref": "#/$defs/morphemeslist"
+              }
+        }
+          },
+          "transparent": {
+            "format": "categories",
+            "basicCategoryTitle": "basic",
+            "description": "A dict of the elements that are transparent to this process, as listed under the keys `segments` and `morphemes:",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "segments": {
+                "description": "A list of dicts of the segments that are transparent to the process, as listed under the keys `units` and `positional_restriction`.",
+                "$ref": "#/$defs/segmentslist"
+              },
+              "morphemes": {
+                "description": "A list of dicts of morphemes that are transparent to the process, as listed under the keys `units` and `positional_restriction`.",
+                "$ref": "#/$defs/morphemeslist"
+              }
+        }
+          },
+          "opaque": {
+            "format": "categories",
+            "basicCategoryTitle": "basic",
+            "description": "A dict of the elements that are opaque to this process. The elements are described by a dict:",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "segments": {
+                "description": "A list of dicts of the segments that are opaque to the process, as listed under the keys `units` and `positional_restriction`.",
+                "$ref": "#/$defs/segmentslist"
+              },
+              "morphemes": {
+                "description": "A list of dicts of morphemes that are opaque to the process, as listed under the keys `units` and `positional_restriction`.",
+                "$ref": "#/$defs/morphemeslist"
+              }
+        }
+          }
+        }
+      }
+    },
+    "source": {
+      "format": "categories",
+      "basicCategoryTitle": "basic",
+      "type": "object",
+      "required": [
+        "summary",
+        "citation",
+        "phonemes",
+        "morphemes",
+        "processdetails"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "summary": {
+          "description": "A prose description of the source materials. (TODO: rename field?)",
+          "type": "string"
+        },
+        "citation": {
+          "description": "One or more bibliographic citations for the source",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "minItems": 1
+        },
+        "natural_classes": { "$ref": "#/$defs/natural_classes" },
+        "phonemes": { "$ref": "#/$defs/phonemes" },
+        "morphemes": { "$ref": "#/$defs/morphemes" },
+        "processdetails": { "$ref": "#/$defs/processdetails" },
+        "laryngeal_harmony": { "$ref": "#/$defs/laryngeal_harmony" },
+        "tone": { "$ref": "#/$defs/tone" }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Hi Jiacheng,

I would like you to accept this pull request so that we can make sure our schemas are aligned going forward. You'll see that I've updated the editor to use the schema found in the local file `saphonlang.schema.json`. If you run your own http server and load the editor, then this schema file will be fetched automatically. (Look for a commented out `schemaUrl` for an example of fetching a non-local url as an alternative.)

I also updated the css in the editor and changed the 'Show Descriptions' control so that it works with the external schema. The checkbox is in an awkward location, but it's usable and good enough for now. (Don't spend any time trying to move it at this point.)

After merging this pull request, you will make schema updates to `saphonlang.schema.json` in order to update the schema. This will allow us to coordinate changes to the schema more easily than when it is embedded in the `.htm` file.

I tried to find substantive changes in the schema embedded in your `.htm` file and put them in `saphonlang.schema.json`. Possibly I missed some things that you and Lev added, so please take a look and edit `saphonlang.schema.json` to re-add them if needed.

Let me know if you have questions about the above or have trouble merging this pull request.

Best,

ronald